### PR TITLE
Fixed Relative path traversal bug in Intervention/Image 

### DIFF
--- a/src/Intervention/Image/Commands/ExifCommand.php
+++ b/src/Intervention/Image/Commands/ExifCommand.php
@@ -29,7 +29,19 @@ class ExifCommand extends AbstractCommand
         // try to read exif data from image file
         try {
             $data = @exif_read_data($image->dirname . '/' . $image->basename);
-
+            
+            // recursively sanitize the data from exif
+            $data = array_map(function($element){
+                $res = null;
+                if(is_array($element)){
+                    $res = array_map('htmlspecialchars', $element);
+                }
+                else {
+                    $res = htmlspecialchars($element, ENT_QUOTES, 'UTF-8');
+                }
+                return $res;
+            }, $data);
+            
             if (!is_null($key) && is_array($data)) {
                 $data = array_key_exists($key, $data) ? $data[$key] : false;
             }

--- a/src/Intervention/Image/Commands/ExifCommand.php
+++ b/src/Intervention/Image/Commands/ExifCommand.php
@@ -30,18 +30,6 @@ class ExifCommand extends AbstractCommand
         try {
             $data = @exif_read_data($image->dirname . '/' . $image->basename);
             
-            // recursively sanitize the data from exif
-            $data = array_map(function($element){
-                $res = null;
-                if(is_array($element)){
-                    $res = array_map('htmlspecialchars', $element);
-                }
-                else {
-                    $res = htmlspecialchars($element, ENT_QUOTES, 'UTF-8');
-                }
-                return $res;
-            }, $data);
-            
             if (!is_null($key) && is_array($data)) {
                 $data = array_key_exists($key, $data) ? $data[$key] : false;
             }

--- a/src/Intervention/Image/ImageManager.php
+++ b/src/Intervention/Image/ImageManager.php
@@ -51,6 +51,10 @@ class ImageManager
      */
     public function make($data)
     {
+        // path traversal mitigation
+        if (strpos($data, '..') !== false) {
+            $data = str_replace('..', '', $data);
+        } 
         return $this->createDriver()->init($data);
     }
 


### PR DESCRIPTION
### 📊 Metadata *

Fixed Directory Traversal bug.

#### Bounty URL: https://www.huntr.dev/bounties/1-packagist-intervention%2Fimage

### ⚙️ Description *

`intervention/image` is an image handling and manipulation library. This package is vulnerable to Directory Traversal attack.

### 💻 Technical Description *

A path traversal issue exists in the program which can be used to access files anywhere in the system and save them as different files. Its caused due to the improper sanitization of the filename, so the fix would be to validate the file name and check whether it contains `..` characters. 

### 🐛 Proof of Concept (PoC) *

Same as PoC given in the bounty description.

```php
<?php

require 'vendor/autoload.php';

$imageFilename = '../2/image-2.jpg';

// import the Intervention Image Manager Class
use Intervention\Image\ImageManagerStatic as Image;

// open an image file
$img = Image::make('uploads/1/'.$imageFilename);

// now you are able to resize the instance
$img->resize(320, 240);

// finally we save the image as a new file
$img->save('uploads/1/newphoto.jpeg');
```

![image](https://user-images.githubusercontent.com/16708391/99845923-70f59500-2b9b-11eb-8eb1-4363dd23ba9e.png)


### 🔥 Proof of Fix (PoF) *

After applying the fix, it doesn't save the file anymore - instead, it throws an exception saying `Image source not readable`, which is intended.

![image](https://user-images.githubusercontent.com/16708391/99846310-1b6db800-2b9c-11eb-85b9-ae0246768b73.png)


### 👍 User Acceptance Testing (UAT)

Just sanitized the filename, no breaking changes introduced. 
:)
